### PR TITLE
Fix type error in getComments

### DIFF
--- a/src/settings-suggester.ts
+++ b/src/settings-suggester.ts
@@ -29,7 +29,8 @@ const ALLOWED_SETTINGS = [
     'powermode.customCss',
 ]
 
-let comments: Comment[] = null;;
+let comments: Comment[] = null;
+
 export class SettingsSuggester {
 
     public settingSuggestions: boolean = true;

--- a/src/settings-suggester.ts
+++ b/src/settings-suggester.ts
@@ -124,6 +124,7 @@ export class SettingsSuggester {
             return comments;
         }).catch(e => {
               console.error(e);
+              return [];
         });
     }
 }


### PR DESCRIPTION
When running `npm run compile` I get the following error which this pull resolves. I also couldn't resist refactoring `getComments` a bit to try and make the lazy load behavior more clear. These changes should not effect behavior at all. Verified the autocomplete still works. 

```
src/settings-suggester.ts(72,9): error TS2322: Type 'Promise<void | Comment[]>' is not assignable to type 'Promise<Comment[]>'.
  Type 'void | Comment[]' is not assignable to type 'Comment[]'.
    Type 'void' is not assignable to type 'Comment[]'.
```