### PR TITLE
Fix for explosion is ontop of text

### DIFF
--- a/src/cursor-exploder/cursor-exploder.ts
+++ b/src/cursor-exploder/cursor-exploder.ts
@@ -175,7 +175,7 @@ export class CursorExploder implements Plugin {
             width: `${this.config.explosionSize}ch`,
             height: `${this.config.explosionSize}rem`,
             display: `inline-block`,
-            ['z-index']: 1,
+            ['z-index']: -1,
         };
 
         const backgroundCssString = this.objectToCssString(backgroundCss);


### PR DESCRIPTION
The explosion was ontop of the text in the editor so while the explosion was playing you could not click in the text behind and set a cursor position. This is mainly a problem with large and long playing animations.

The value of -1 is valid as of this: https://www.w3schools.com/cssref/pr_pos_z-index.asp