### PR TITLE
Restoring the vertical shake

### DIFF
--- a/src/screen-shaker/screen-shaker.ts
+++ b/src/screen-shaker/screen-shaker.ts
@@ -37,11 +37,11 @@ export class ScreenShaker implements Plugin {
         });
 
         this.negativeY = vscode.window.createTextEditorDecorationType(<vscode.DecorationRenderOptions>{
-            textDecoration: `none; margin-top: 0px;`
+            textDecoration: `none; line-height:inherit`
         });
 
         this.positiveY = vscode.window.createTextEditorDecorationType(<vscode.DecorationRenderOptions>{
-            textDecoration: `none; margin-top: ${this.config.shakeIntensity}px;`
+            textDecoration: `none; line-height:${(this.config.shakeIntensity/2)+1};`,
         });
 
         this.shakeDecorations = [


### PR DESCRIPTION
Introducing vertical shake via margin-top broke a while ago but it is still possible to get the same effect by tweaking the `line height` property instead.  
The shakeIntensity value has to be converted from its usual px value for this and `(shakeIntensity/2)+1` syncs up both axis pretty evenly.