### PR TITLE
Show the combo counter after a threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,12 @@
             "minimum": 0,
             "description": "Control the size of the Combo Meter text"
           },
+          "powermode.combo.counterThreshold": {
+            "type": "number",
+            "default": 1,
+            "minimum": 1,
+            "description": "The combo number needed to show the counter."
+          },
           "powermode.combo.timerEnabled": {
             "type": "string",
             "default": "default",

--- a/src/combo/combo-plugin.ts
+++ b/src/combo/combo-plugin.ts
@@ -19,6 +19,7 @@ export class ComboPlugin implements Plugin {
             enableComboTimer: comboFeatureConfigToBoolean(getConfigValue<ComboFeatureConfig>("combo.timerEnabled", config)),
             enableComboCounter: comboFeatureConfigToBoolean(getConfigValue<ComboFeatureConfig>("combo.counterEnabled", config)),
             comboCounterSize: getConfigValue<number>("combo.counterSize", config),
+            comboCounterThreshold: getConfigValue<number>("combo.counterThreshold", config),
         }
 
         if (this.config.comboLocation !== oldLocation) {

--- a/src/combo/config.ts
+++ b/src/combo/config.ts
@@ -9,4 +9,5 @@ export interface ComboPluginConfig {
     enableComboTimer: boolean;
     enableComboCounter: boolean;
     comboCounterSize: number;
+    comboCounterThreshold: number;
 }

--- a/src/combo/editor-combo-meter.ts
+++ b/src/combo/editor-combo-meter.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { Plugin, PowermodeChangeTextDocumentEventData } from '../plugin';
 import { ComboPluginConfig } from './config';
 
-export type EditorComboMeterConfig = Pick<ComboPluginConfig, "enableComboCounter" | "enableComboTimer" | "comboCounterSize">;
+export type EditorComboMeterConfig = Pick<ComboPluginConfig, "enableComboCounter" | "enableComboTimer" | "comboCounterSize" | "comboCounterThreshold">;
 
 export class EditorComboMeter implements Plugin<EditorComboMeterConfig> {
 
@@ -135,8 +135,9 @@ export class EditorComboMeter implements Plugin<EditorComboMeterConfig> {
         }
 
         const firstVisibleRange = editor.visibleRanges.sort().find(range => !range.isEmpty);
+        const comboThreshold = this.config?.comboCounterThreshold || 1;
 
-        if (!firstVisibleRange || this.combo < 1) {
+        if (!firstVisibleRange || this.combo < comboThreshold) {
             this.removeDecorations();
             return;
         }

--- a/src/config/configuration-keys.ts
+++ b/src/config/configuration-keys.ts
@@ -6,6 +6,7 @@ export const ConfigurationKeys = [
     "combo.timeout",
     "combo.counterEnabled",
     "combo.counterSize",
+    "combo.counterThreshold",
     "combo.timerEnabled",
     "shake.enabled",
     "shake.intensity",


### PR DESCRIPTION
This PR adds a configurable threshold, and does not show the combo counter until that threshold is reached.

This hides the combo counter for small edits and stray keystrokes, but creates a buildup of intensity as you start typing more and more! First the combo counter eventually appears to warn you, and then POWER MODE is achieved!

I haven't touched TypeScript in >10 years so the code may be rough -- I am very willing to make further changes, or please push into the PR as needed!