### PR TITLE
[hotfix] combo meter top right alignment css

### DIFF
--- a/src/combo/editor-combo-meter.ts
+++ b/src/combo/editor-combo-meter.ts
@@ -29,7 +29,7 @@ export class EditorComboMeter implements Plugin<EditorComboMeterConfig> {
         // NOTE: This positions the element off the screen when there is horizontal scroll
         // so this feature works best when "word wrap" is enabled.
         // Using "5vw" instead did not limit the position to the viewable width.
-        right: "5%",
+        left: "calc(100vw - 25rem)",
         top: "20px",
 
         ['font-family']: "monospace",


### PR DESCRIPTION
## combo meter show left issue fix

Recently, the combo was skewed to the left, and I had a problem covering my code.
I modified the css so that I can fix the combo to the top right.
It worked for me.

![2024-05-1202-59-40-ezgif com-video-to-gif-converter (1)](https://github.com/hoovercj/vscode-power-mode/assets/20130681/7aa8c072-7064-4720-b684-15d1be767be6)

related issue #113 #112 
